### PR TITLE
set the release_version env variable

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ jobs:
         run: |
           set -euxo pipefail
           release_version=`echo ${{ github.ref_name }} | grep -Eo '[0-9]+.[0-9]+.[0-9]+'`
+          echo "release_version=$release_version" >> $GITHUB_ENV
       - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
Forgot to set the `$release_version` environment variable for the next steps in the workflow