### PR TITLE
Use the cashapp/check-signature-action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,13 +23,13 @@ jobs:
           java-version: 17
       - name: Setup gradle
         uses: gradle/gradle-build-action@v2
-      - name: Verify release tag
-        run: |
-          set -euxo pipefail
-          cd ${{ github.workspace }}
-          git config gpg.ssh.allowedSignersFile ./config/allowed_release_signers
-          git fetch --tags -f
-          git tag -v ${{ github.ref_name }}
+      - name: "Verify release tag"
+        uses: cashapp/check-signature-action@v0.2.0
+        id: check-tag-sig
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          allowed-release-signers: yoavamit
       - name: Build library
         uses: gradle/gradle-build-action@v2
         with:

--- a/config/allowed_release_signers
+++ b/config/allowed_release_signers
@@ -1,1 +1,0 @@
-yoav@squareup.com sk-ecdsa-sha2-nistp256@openssh.com AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTYAAABBBMm3lkzyQNOJu7OSrgAvfrld8qmNfFEUMZxTl5eSGteGNTOpreS2RjMRixo/wxXEb5iGCzYfizb5qeNzSH17lZ4AAAAEc3NoOg==


### PR DESCRIPTION
Use the cashapp/check-signature-action GitHub Action, instead of running the inline bash script to verify that the release tag was signed.