### PR TITLE
Add missing POM properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,9 @@
 GROUP=app.cash.jooq
 POM_ARTIFACT_ID=jooq-encryption
 
+POM_NAME=jooq-encryption
+POM_DESCRIPTION=A library that provides application layer encryption of database columns using the jOOQ ORM
+
 POM_URL=https://github.com/cashapp/jooq-encryption/
 POM_SCM_URL=https://github.com/cashapp/jooq-encryption/
 POM_SCM_CONNECTION=scm:git:git://github.com/cashapp/jooq-encryption.git


### PR DESCRIPTION
This should fix the following error when publishing the project to Maven:
```
* What went wrong:
Failed to stop service 'sonatype-repository-build-service'.
> Closing the repository failed with the following errors:
  Invalid POM: /app/cash/jooq/jooq-encryption/1.0.1/jooq-encryption-1.0.1.pom: Project name missing, Project description missing
```