### PR TITLE
Fixed the Github Actions release flow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Check release version number
         run: |
@@ -22,11 +24,11 @@ jobs:
         run: |
           git branch -r --contains ${{ github.ref }} | grep -q "origin/main" || exit 1
 
-      - name: Setup JDK 17
+      - name: Setup JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
 
       - name: Verify release tag
         uses: cashapp/check-signature-action@4a792302844562be691e29acc1a4d129503dec39


### PR DESCRIPTION
The "Check if tag is on main branch" step is failing because actions/checkout@v4 defaults to fetch-depth: 1, so it only fetches the tagged commit.

This PR fixes it.